### PR TITLE
[mapplauncherd-qt5] Don't kill boosters when signaling boot complete. JB#53997

### DIFF
--- a/data/booster-qt5-signal.service
+++ b/data/booster-qt5-signal.service
@@ -6,5 +6,5 @@ After=booster-qt5.service post-user-session.target
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStart=-/usr/bin/killall -SIGUSR1 booster-qt5
+ExecStart=-/usr/bin/systemctl --user kill --signal=SIGUSR1 --kill-who=main booster-qt5.service
 


### PR DESCRIPTION
Use systemctl to send SIGUSR1 to the main booster process instead of
killall which would also send the signal to forked processes.